### PR TITLE
fix: URL in curl command of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Alternatively, use the below command, replacing `$VERSION`, `$OSTYPE`
 as required:
 
 ```shell-session
-$ curl -fSsL "https://github.com/coder/coder-doctor/releases/download/${VERSION}/coder-doctor_${VERSION}_${OSTYPE}_${ARCH}.tar.gz" | tar -xzvf -
+$ curl -fSsL "https://github.com/coder/coder-doctor/releases/download/v${VERSION}/coder-doctor_${VERSION}_${OSTYPE}_${ARCH}.tar.gz" | tar -xzvf -
 README.md
 coder-doctor
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Alternatively, use the below command, replacing `$VERSION`, `$OSTYPE`
 as required:
 
 ```shell-session
-$ curl -fSsL "https://github.com/cdr/coder-doctor/releases/latest/download/coder-doctor_${VERSION}_${OSTYPE}_${ARCH}.tar.gz" | tar -xzvf -
+$ curl -fSsL "https://github.com/coder/coder-doctor/releases/download/${VERSION}/coder-doctor_${VERSION}_${OSTYPE}_${ARCH}.tar.gz" | tar -xzvf -
 README.md
 coder-doctor
 ```


### PR DESCRIPTION
Executing the **Curl** Command of `README.md`, after subsitution of correct env vars, gives the following result:

```
curl: (22) The requested URL returned error: 404
gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

Thus, I fixed the command to the correct URL, keeping the env var semantic intact.
